### PR TITLE
Avoid error

### DIFF
--- a/Model/Lpm/Config.php
+++ b/Model/Lpm/Config.php
@@ -73,7 +73,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     /**
      * @var array
      */
-    private $allowedMethods;
+    private $allowedMethods = [];
 
     /**
      * @var Repository
@@ -122,7 +122,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     {
         $allowedMethods = explode(
             ',',
-            $this->getValue(
+            (string) $this->getValue(
                 self::KEY_ALLOWED_METHODS,
                 $this->storeConfigResolver->getStoreId()
             )


### PR DESCRIPTION
The error occurs when all payment methods are disabled in "Allowed Payment Methods" field of  "Local Payment Methods" section